### PR TITLE
Fix dereferencing the free'd oct_dev pointer.

### DIFF
--- a/drivers/phc/ep_phc.c
+++ b/drivers/phc/ep_phc.c
@@ -633,7 +633,6 @@ void octeon_ep_phc_remove(struct pci_dev *pdev)
 				oct_idx);
 			schedule_timeout_interruptible(HZ * 1);
 		}
-		goto before_exit;
 	}
 
 	atomic_set(&oct_dev->status, OCT_DEV_STOPPING);
@@ -666,9 +665,6 @@ void octeon_ep_phc_remove(struct pci_dev *pdev)
 	 * data structure to reflect this. Free the device structure.
 	 */
 	octeon_free_device_mem(oct_dev);
-
-before_exit:
-	dev_info(&oct_dev->pci_dev->dev, "OCT_PHC[%d]: Octeon device removed\n", oct_idx);
 }
 
 


### PR DESCRIPTION
Hello,
I'm a member of Montis vRAN NIC team in Samsung.
I found a dereferencing free'd pointer bug which makes segmentation fault error during `rmmod oct_ep_phc` as below:
Please review and pull this fix.
Thanks,

\# rmmod oct_ep_phc
[ 878.354856] Octeon EP PHC 0001:01:00.1: OCT_PHC[0]: Stopping octeon device
[ 878.361814] Octeon EP PHC 0001:01:00.1: OCT_PHC[0]: Freeing PCI mapped regions for Bar0
[ 878.369816] Octeon EP PHC 0001:01:00.1: OCT_PHC[0]: Freeing PCI mapped regions for Bar1
[ 878.377809] Octeon EP PHC 0001:01:00.1: OCT_PHC[0]: Freeing PCI mapped regions for Bar2
[ 878.385803] Octeon EP PHC 0001:01:00.1: OCT_PHC[0]: BAR unmapped.
[ 878.391900] Unable to handle kernel paging request at virtual address ffff8000080d7078
[ 878.399833] Mem abort info:
[ 878.402624] ESR = 0x96000007
[ 878.405671] EC = 0x25: DABT (current EL), IL = 32 bits
[ 878.410977] SET = 0, FnV = 0
[ 878.414024] EA = 0, S1PTW = 0
[ 878.417159] FSC = 0x07: level 3 translation fault
[ 878.422032] Data abort info:
[ 878.424905] ISV = 0, ISS = 0x00000007
[ 878.428733] CM = 0, WnR = 0
[ 878.431693] swapper pgtable: 4k pages, 48-bit VAs, pgdp=00000000f3995000
[ 878.438385] [ffff8000080d7078] pgd=10000083fffff003, p4d=10000083fffff003, pud=10000083ffffe003, pmd=10000083ffffd003, pte=0000000000000000
[ 878.450899] Internal error: Oops: 96000007 [#1] SMP
[ 878.455763] Modules linked in: oct_ep_phc(E-) nls_iso8859_1 aes_ce_blk aes_ce_cipher crct10dif_ce ghash_ce sha2_ce sha256_arm64 sha1_ce plx_dma efi_pstore arm_cmn arm_spe_pmu sbsa_gwdt sch_fq_codel vfio_pci vfio_pci_core vfio_virqfd vfio_iommu_type1 vfio ip_tables x_tables autofs4 r8169 xhci_pci ahci xhci_pci_renesas realtek [last unloaded: oct_ep_phc]
[ 878.486949] CPU: 0 PID: 578 Comm: rmmod Tainted: G E 5.18.4+ [#1](https://cavium.assembla.com/spaces/atLcdMPkar7l_dcP_HzTya/tickets/1)
[ 878.494157] pstate: 80400009 (Nzcv daif +PAN -UAO -TCO -DIT -SSBS BTYPE=--)
[ 878.501104] pc : octeon_ep_phc_remove+0xfc/0x128 [oct_ep_phc]
[ 878.506838] lr : octeon_ep_phc_remove+0xfc/0x128 [oct_ep_phc]
[ 878.512570] sp : ffff80000b4b3ae0
[ 878.515871] x29: ffff80000b4b3ae0 x28: ffff00800add9080 x27: 0000000000000000
[ 878.522992] x26: ffff80000a6cac60 x25: ffff008000cd2150 x24: ffff80000a6cac78
[ 878.530114] x23: ffff800001273208 x22: ffff8000080d7208 x21: 0000000000000000
[ 878.537235] x20: ffff8000012730c0 x19: ffff8000080d7000 x18: 0000000000000000
[ 878.544357] x17: 0000000000000000 x16: 0000000000000000 x15: 0000000000000000
[ 878.551477] x14: ffff80000a398468 x13: ffff80000a3978a0 x12: 0000000000000000
[ 878.558599] x11: 0000000000000004 x10: 0000000000000c40 x9 : 0000000000000000
[ 878.565720] x8 : ffff00800add9d20 x7 : ffff0080008e5a10 x6 : ffff80000a35e000
[ 878.572841] x5 : 1d90630814364341 x4 : fffffc0200240f20 x3 : 000000008020001b
[ 878.579962] x2 : 0000000000000000 x1 : 0000000000000000 x0 : ffff800001273a90
[ 878.587084] Call trace:
[ 878.589517] octeon_ep_phc_remove+0xfc/0x128 [oct_ep_phc]
[ 878.594902] pci_device_remove+0x48/0xe0
[ 878.598814] device_remove+0x54/0x90
[ 878.602377] device_release_driver_internal+0x204/0x2b4
[ 878.607590] driver_detach+0x5c/0xec
[ 878.611151] bus_remove_driver+0x78/0x130
[ 878.615148] driver_unregister+0x3c/0x6c
[ 878.619057] pci_unregister_driver+0x30/0xa4
[ 878.623313] phc_exit+0x1c/0x708 [oct_ep_phc]
[ 878.627656] __arm64_sys_delete_module+0x18c/0x2b0
[ 878.632435] invoke_syscall+0x78/0x100
[ 878.636171] el0_svc_common.constprop.0+0x58/0x190
[ 878.640949] do_el0_svc+0x30/0x90
[ 878.644251] el0_svc+0x4c/0x1b4
[ 878.647380] el0t_64_sync_handler+0xe8/0xf0
[ 878.651550] el0t_64_sync+0x1a0/0x1a4
[ 878.655200] Code: aa1303e0 97fffd1a aa1303e0 97fffc98 (f9403e60)
[ 878.661279] ---[ end trace 0000000000000000 ]---
Segmentation fault
